### PR TITLE
Handle missing cached_tokens for openai compatible endpoints

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -8,6 +8,7 @@ import concurrent.futures
 import base64
 import tempfile
 import asyncio
+import aiohttp  # Must be explicitly imported to catch its errors
 from functools import lru_cache
 from defusedxml import ElementTree
 import yfinance
@@ -555,7 +556,8 @@ def handle_text_generation(current_message, messages, channel_id, root_id, initi
 
     initial_message_response = response.choices[0].message
     prompt_tokens = response.usage.prompt_tokens
-    cached_prompt_tokens = response.usage.prompt_tokens_details.cached_tokens
+    prompt_details = getattr(response.usage, 'prompt_tokens_details', None)
+    cached_prompt_tokens = getattr(prompt_details, 'cached_tokens', 0)
     completion_tokens = response.usage.completion_tokens
 
     # Check if tool calls are present in the response

--- a/chatbot.py
+++ b/chatbot.py
@@ -8,7 +8,6 @@ import concurrent.futures
 import base64
 import tempfile
 import asyncio
-import aiohttp  # Must be explicitly imported to catch its errors
 from functools import lru_cache
 from defusedxml import ElementTree
 import yfinance


### PR DESCRIPTION
When testing the bot, I encountered an crash as my openai endpoint was not returning a value for `cached_tokens`. This returns 0 if the attribute is not set.